### PR TITLE
Improve accessible theme toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -47,7 +47,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/afys-news.html
+++ b/afys-news.html
@@ -47,6 +47,9 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
+                <i class="fas fa-moon" aria-hidden="true"></i>
+            </button>
             <ul class="nav-menu" id="main-nav-menu">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="afys-profile.html">About AFYS</a></li>

--- a/afys-profile.html
+++ b/afys-profile.html
@@ -48,7 +48,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/center-for-empowerment.html
+++ b/center-for-empowerment.html
@@ -48,7 +48,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/contact.html
+++ b/contact.html
@@ -46,7 +46,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/ewb-interview.html
+++ b/ewb-interview.html
@@ -43,7 +43,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/ewb-profile.html
+++ b/ewb-profile.html
@@ -47,7 +47,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/initiatives.html
+++ b/initiatives.html
@@ -47,7 +47,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/js/script.js
+++ b/js/script.js
@@ -32,10 +32,18 @@ document.addEventListener('DOMContentLoaded', function() {
         if (savedTheme === 'dark') {
             bodyEl.classList.add('dark');
             themeToggle.innerHTML = '<i class="fas fa-sun" aria-hidden="true"></i>';
+            themeToggle.setAttribute('aria-label', 'Activate light mode');
+            themeToggle.setAttribute('aria-pressed', 'true');
+        } else {
+            themeToggle.setAttribute('aria-label', 'Activate dark mode');
+            themeToggle.setAttribute('aria-pressed', 'false');
         }
+
         themeToggle.addEventListener('click', () => {
             const isDark = bodyEl.classList.toggle('dark');
             themeToggle.innerHTML = isDark ? '<i class="fas fa-sun" aria-hidden="true"></i>' : '<i class="fas fa-moon" aria-hidden="true"></i>';
+            themeToggle.setAttribute('aria-label', isDark ? 'Activate light mode' : 'Activate dark mode');
+            themeToggle.setAttribute('aria-pressed', isDark.toString());
             localStorage.setItem('theme', isDark ? 'dark' : 'light');
         });
     }

--- a/news.html
+++ b/news.html
@@ -47,7 +47,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/partnerships.html
+++ b/partnerships.html
@@ -47,7 +47,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">

--- a/programs.html
+++ b/programs.html
@@ -47,7 +47,7 @@
             <button class="menu-toggle" id="mobile-menu" aria-label="Open navigation menu" aria-expanded="false" aria-controls="main-nav-menu">
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
-            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Activate dark mode" aria-pressed="false">
                 <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
             <ul class="nav-menu" id="main-nav-menu">


### PR DESCRIPTION
## Summary
- mark theme toggle button with `aria-pressed`
- add missing theme toggle on the AFYS news page
- update script to sync `aria-label` and `aria-pressed` with theme state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6856858428608321a4dfdfdccde96434