### PR TITLE
Define logo class for empowerment page

### DIFF
--- a/center-for-empowerment.html
+++ b/center-for-empowerment.html
@@ -65,7 +65,7 @@
     <main>
         <section class="page-header-simple" style="background: linear-gradient(45deg, hsla(from var(--afys-secondary) h s l / 0.1), hsla(from var(--afys-primary) h s l / 0.1));">
             <div class="container text-center">
-                <img src="images/afys/center-for-empowerment-logo.png" alt="Center for Empowerment Logo" style="max-width: 200px; margin: 0 auto 1.5rem;">
+                <img src="images/afys/center-for-empowerment-logo.png" alt="Center for Empowerment Logo" class="center-logo-large">
                 <h1>Center for Young Scientist and Graduate Empowerment for Entrepreneurship and Employment</h1>
                 <p class="lead-text">An AFYS initiative dedicated to aligning graduate skills with market demands, fostering innovation, and driving employment in line with Egypt's Vision 2030.</p>
             </div>

--- a/css/style.css
+++ b/css/style.css
@@ -262,6 +262,12 @@ header nav { display: flex; justify-content: space-between; align-items: center;
 .center-highlight-card h3 { font-size: 1.5rem; color: var(--text-primary); }
 .center-highlight-card p { color: var(--text-secondary); max-width: 600px; margin-left: auto; margin-right: auto; margin-bottom: 2rem; }
 
+/* Center Page Logo */
+.center-logo-large {
+    max-width: 200px;
+    margin: 0 auto 1.5rem;
+}
+
 /* EWB Page Components */
 .services-banner-full { padding: 2rem; background-color: #eef1f3; border-radius: var(--border-radius-md); box-shadow: var(--shadow-light); margin-bottom: 2rem; text-align: center; }
 .services-banner-full img { max-width: 100%; height: auto; max-height: 450px; object-fit: contain; border-radius: var(--border-radius-sm); box-shadow: none; }


### PR DESCRIPTION
## Summary
- add `.center-logo-large` class to reuse style for the empowerment page logo
- switch logo's inline styling to use the new class

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68568c8ff9f88321a1d9c76459ae491f